### PR TITLE
Support initializing a MultiRange object with unsorted ranges

### DIFF
--- a/lib/multi_range.rb
+++ b/lib/multi_range.rb
@@ -19,8 +19,8 @@ class MultiRange
 
   attr_reader :ranges
 
-  def initialize(ranges) # range 要由小到大排序，且各 range 不能重疊
-    @ranges = ranges.map{|s| s.is_a?(Integer) ? s..s : s }.freeze
+  def initialize(ranges)
+    @ranges = ranges.map{|s| s.is_a?(Integer) ? s..s : s }.sort_by(&:begin).freeze
   end
 
   def flatten

--- a/test/multi_range_test.rb
+++ b/test/multi_range_test.rb
@@ -14,6 +14,11 @@ class MultiRangeTest < Minitest::Test
     assert_equal [1..1, 4..6, 9..9], MultiRange.new([1, 4..6, 9]).ranges
   end
 
+  def test_unsorted_ranges
+    assert_equal @multi_range.ranges, MultiRange.new([4..5, 0..2]).ranges
+    assert_equal [12..12, 20..20, 21..21, 24..26, 30..31], MultiRange.new([30..31, 12, 24..26, 21, 20]).ranges
+  end
+
   def test_flatten
     multi_range = MultiRange.new([1, 2, 4..6, 7, 8..12])
     assert_equal [1..2, 4..12], multi_range.flatten.ranges


### PR DESCRIPTION
Previously, it will cause problems when you pass unsorted ranges to MultiRange. Ex:
```rb
MultiRange.new([4..5, 0..2])
```