### PR TITLE
Add sort_ranges parameter and range_combine_end method for PostgreSQL 14 compatibility

### DIFF
--- a/lib/multi_range.rb
+++ b/lib/multi_range.rb
@@ -25,15 +25,9 @@ class MultiRange
   def initialize(ranges)
     if ranges.is_a? MultiRange
       @ranges = ranges.ranges
-      @is_float = ranges.is_float?
     else
-      @ranges = ranges.map{|s| s.is_a?(Numeric) ? s..s : s }.sort_by(&:begin).freeze
-      @is_float = @ranges.any?{|range| range.begin.is_a?(Float) || range.end.is_a?(Float) }
+      @ranges = ranges.map{ |s| s.is_a?(Numeric) ? s..s : s }.sort_by(&:begin).freeze
     end
-  end
-
-  def is_float?
-    @is_float
   end
 
   def merge_overlaps(merge_same_value = true)
@@ -189,8 +183,7 @@ class MultiRange
   # make sure that range1.begin <= range2.begin
   def can_combine?(range1, range2, merge_same_value)
     return merge_same_value if range1.end == range2.begin and range1.exclude_end?
-    return range1.end >= range2.begin if @is_float
-    return range1.end + 1 >= range2.begin
+    range_combine_end(range1, false) >= range2.begin
   end
 
   def difference_with_other_multi_range(other)
@@ -202,11 +195,7 @@ class MultiRange
   def possible_sub_ranges_of(range, other)
     sub_range1 = range.begin...other.begin
 
-    sub_range2_begin = if other.exclude_end?
-                         other.end
-                       else
-                         other.end + (other.end.is_a?(Float) ? Float::EPSILON : 1)
-                       end
+    sub_range2_begin = range_combine_end(other)
 
     sub_range2 = range.exclude_end? ? sub_range2_begin...range.end : sub_range2_begin..range.end
 
@@ -214,6 +203,26 @@ class MultiRange
     sub_ranges << sub_range1 if sub_range1.begin < sub_range1.end
     sub_ranges << sub_range2 if sub_range2.begin < sub_range2.end
     return sub_ranges
+  end
+
+  LESS_THAN_MICROSECOND = Rational(1, 10**6 + 1)
+  DATETIME_LESS_THAN_MICROSECOND = LESS_THAN_MICROSECOND * Rational(1, 86400)
+  def range_combine_end(range, increase_float = true)
+    range_end = range.end
+    return range_end if range.exclude_end?
+
+    case range_end
+    when Float
+      increase_float ? range_end.next_float : range_end
+    when Time # ActiveSupport::TimeWithZone
+      range_end + LESS_THAN_MICROSECOND
+    else
+      if defined?(DateTime) && range_end.is_a?(DateTime)
+        range_end + DATETIME_LESS_THAN_MICROSECOND
+      else # Date, Integer
+        range_end + 1
+      end
+    end
   end
 
   def overlaps_with_range?(range)

--- a/lib/multi_range.rb
+++ b/lib/multi_range.rb
@@ -22,11 +22,13 @@ class MultiRange
 
   attr_reader :ranges
 
-  def initialize(ranges)
+  def initialize(ranges, sort_ranges: true)
     if ranges.is_a? MultiRange
       @ranges = ranges.ranges
     else
-      @ranges = ranges.map{ |s| s.is_a?(Numeric) ? s..s : s }.sort_by(&:begin).freeze
+      @ranges = ranges.map{ |s| s.is_a?(Numeric) ? s..s : s }
+      @ranges = @ranges.sort_by(&:begin) if sort_ranges
+      @ranges = @ranges.freeze
     end
   end
 

--- a/multi_range.gemspec
+++ b/multi_range.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '>= 10.5.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'backports', '~> 3.15.0'
+  spec.add_development_dependency 'activesupport', '~> 7.0'
 
   spec.add_dependency 'roulette-wheel-selection', '~> 1.1.1'
   spec.add_dependency 'fast_interval_tree', '~> 0.2.0'

--- a/test/contain_overlap_test.rb
+++ b/test/contain_overlap_test.rb
@@ -53,7 +53,7 @@ class ContainOverlapTest < Minitest::Test
     assert_equal true, MultiRange.new([Date.new(2001,2,3)..Date.new(2002,3,10), Date.new(2002,3,4)..Date.new(2002,3,10)]).contain_overlaps?
   end
 
-  def test_time_overlaps_at_less_than_microsecond
+  def test_time_overlaps
     assert_equal false, MultiRange.new(
                    [
                      Time.at(0)..Time.at(1),
@@ -77,8 +77,36 @@ class ContainOverlapTest < Minitest::Test
 
     assert_equal true, MultiRange.new(
                    [
-                     Time.at(0)..Time.at(1),
+                     Time.at(0)..Time.at(1, 500, :nsec),
                      Time.at(1,999,:nsec)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1, 500, :nsec),
+                     Time.at(1,1499,:nsec)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1, 499, :nsec),
+                     Time.at(1,999,:nsec)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(1,500,:nsec)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(1,1499,:nsec)..Time.at(4)
                    ]
                  ).contain_overlaps?
 
@@ -97,51 +125,7 @@ class ContainOverlapTest < Minitest::Test
                  ).contain_overlaps?
   end
 
-  def test_date_time_overlaps_at_less_than_microsecond
-    assert_equal false, MultiRange.new(
-                   [
-                     Time.at(0).to_datetime..Time.at(1).to_datetime,
-                     Time.at(3).to_datetime..Time.at(4).to_datetime
-                   ]
-                 ).contain_overlaps?
-
-    assert_equal false, MultiRange.new(
-                   [
-                     Time.at(0).to_datetime..Time.at(1).to_datetime,
-                     Time.at(2).to_datetime..Time.at(4).to_datetime
-                   ]
-                 ).contain_overlaps?
-
-    assert_equal true, MultiRange.new(
-                   [
-                     Time.at(0).to_datetime..Time.at(1).to_datetime,
-                     Time.at(1).to_datetime..Time.at(4).to_datetime
-                   ]
-                 ).contain_overlaps?
-
-    assert_equal true, MultiRange.new(
-                   [
-                     Time.at(0).to_datetime..Time.at(1).to_datetime,
-                     Time.at(1,999,:nsec).to_datetime..Time.at(4).to_datetime
-                   ]
-                 ).contain_overlaps?
-
-    assert_equal false, MultiRange.new(
-                   [
-                     Time.at(0).to_datetime..Time.at(1).to_datetime,
-                     Time.at(1,1,:microsecond).to_datetime..Time.at(4).to_datetime
-                   ]
-                 ).contain_overlaps?
-
-    assert_equal false, MultiRange.new(
-                   [
-                     Time.at(0).to_datetime..Time.at(1).to_datetime,
-                     Time.at(1,1,:millisecond).to_datetime..Time.at(4).to_datetime
-                   ]
-                 ).contain_overlaps?
-  end
-
-  def test_active_support_time_with_timezone_overlaps_less_than_microsecond
+  def test_active_support_time_with_timezone_overlaps
     require 'active_support/time_with_zone'
     require 'active_support/time'
     Time.zone = 'Eastern Time (US & Canada)'
@@ -169,8 +153,36 @@ class ContainOverlapTest < Minitest::Test
 
     assert_equal true, MultiRange.new(
                    [
-                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(0)..Time.zone.at(1, 500, :nsec),
                      Time.zone.at(1,999,:nsec)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1, 500, :nsec),
+                     Time.zone.at(1,1499,:nsec)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1, 499, :nsec),
+                     Time.zone.at(1,999,:nsec)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(1,500,:nsec)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(1,1499,:nsec)..Time.zone.at(4)
                    ]
                  ).contain_overlaps?
 

--- a/test/contain_overlap_test.rb
+++ b/test/contain_overlap_test.rb
@@ -46,4 +46,146 @@ class ContainOverlapTest < Minitest::Test
     assert_equal false, MultiRange.new([1.2..1.5, 1.7..1.8, 3.5..7.2, 1.6...val]).contain_overlaps?
     assert_equal false, MultiRange.new([1.2..1.5, 1.7..1.8, 3.5..7.2, 1.6..val]).contain_overlaps?
   end
+
+  def test_date
+    assert_equal false, MultiRange.new([Date.new(2001,2,3)..Date.new(2001,3,10), Date.new(2002,2,3)..Date.new(2002,3,10)]).contain_overlaps?
+    assert_equal true, MultiRange.new([Date.new(2001,2,3)..Date.new(2002,3,10), Date.new(2002,3,3)..Date.new(2002,3,10)]).contain_overlaps?
+    assert_equal true, MultiRange.new([Date.new(2001,2,3)..Date.new(2002,3,10), Date.new(2002,3,4)..Date.new(2002,3,10)]).contain_overlaps?
+  end
+
+  def test_time_overlaps_at_less_than_microsecond
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(3)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(2)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(1)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(1,999,:nsec)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(1,1,:microsecond)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0)..Time.at(1),
+                     Time.at(1,1,:millisecond)..Time.at(4)
+                   ]
+                 ).contain_overlaps?
+  end
+
+  def test_date_time_overlaps_at_less_than_microsecond
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0).to_datetime..Time.at(1).to_datetime,
+                     Time.at(3).to_datetime..Time.at(4).to_datetime
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0).to_datetime..Time.at(1).to_datetime,
+                     Time.at(2).to_datetime..Time.at(4).to_datetime
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.at(0).to_datetime..Time.at(1).to_datetime,
+                     Time.at(1).to_datetime..Time.at(4).to_datetime
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.at(0).to_datetime..Time.at(1).to_datetime,
+                     Time.at(1,999,:nsec).to_datetime..Time.at(4).to_datetime
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0).to_datetime..Time.at(1).to_datetime,
+                     Time.at(1,1,:microsecond).to_datetime..Time.at(4).to_datetime
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.at(0).to_datetime..Time.at(1).to_datetime,
+                     Time.at(1,1,:millisecond).to_datetime..Time.at(4).to_datetime
+                   ]
+                 ).contain_overlaps?
+  end
+
+  def test_active_support_time_with_timezone_overlaps_less_than_microsecond
+    require 'active_support/time_with_zone'
+    require 'active_support/time'
+    Time.zone = 'Eastern Time (US & Canada)'
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(3)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(2)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(1)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal true, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(1,999,:nsec)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(1,1,:microsecond)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+
+    assert_equal false, MultiRange.new(
+                   [
+                     Time.zone.at(0)..Time.zone.at(1),
+                     Time.zone.at(1,1,:millisecond)..Time.zone.at(4)
+                   ]
+                 ).contain_overlaps?
+  end
 end

--- a/test/multi_range_test.rb
+++ b/test/multi_range_test.rb
@@ -25,6 +25,11 @@ class MultiRangeTest < Minitest::Test
     assert_equal [12..12, 20..20, 21..21, 24..26, 30..31], MultiRange.new([30..31, 12, 24..26, 21, 20]).ranges
   end
 
+  def test_skip_sorting_ranges
+    assert_equal [4..5, 0..2], MultiRange.new([4..5, 0..2], sort_ranges: false).ranges
+    assert_equal [30..31, 12..12, 24..26, 21..21, 20..20], MultiRange.new([30..31, 12, 24..26, 21, 20], sort_ranges: false).ranges
+  end
+
   def test_merge_overlaps
     assert_equal [], @empty_range.merge_overlaps.ranges
 


### PR DESCRIPTION
1. Adding `range_combine_end` method

PostgreSQL 14 handles overlaps slightly differently than the current implementation.

| PG Multirange Column | Ruby Class | Overlap between inclusive end Ranges? |
|----------|---------------------|-----------------|
| int4multirange | `Integer` | end + 1 >= begin |
| int8multirange | `Integer` | end + 1 >= begin |
| nummultirange | `Float` | end >= begin |
| datemultirange | `Date` | end + '1 day' >= begin |
| tsmultirange | `Time` | end >= begin |
| tstzmultirange | `ActiveSupport::TimeWithZone` | end >= begin |

The existing logic to handle overlaps works perfectly for Integers, Floats & Dates. This logic, however, does not work for Time or ActiveSupport::TimeWithZone.

The current logic (`+ 1`) adds 1 day to `Time`, `ActiveSupport::TimeWithZone` - when merge overlaps is called, this can lead to ranges being merged that wouldn't be merged in PostgreSQL.

PostgreSQL truncates timestamps to microseconds and then merges ranges that overlap - I duplicated this logic by adding nanoseconds to handle rounding the end temporarily and then checking if the end is greater or equal to the beginning of the next range.

PostgreSQL is the only Database to have Multiranges - so I believe it is ok for this library duplicate the logic present there.

2. Adding `sort_ranges` parameter to initializer

When working with an already sorted multirange (like when pulling PostgreSQL Multiranges directly from the database), it's going to be a lot faster to have the MultiRange skip sorting the ranges.

I believe this parameter could also be used internally to make the data structure faster in some cases (When creating new ranges during `difference` & `intersection` for example).