### PR TITLE
Drop the support of ruby 2.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,8 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.0
-          - 2.2
+          - 2.3
           - 2.6
           - 2.7
         gemfile:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 
 ## Supports
  
-- Ruby 2.0 ~ 2.7
+- Ruby 2.3 ~ 2.7
 
 For Ruby 1.8.x and 1.9.x, please use multi_range < 2.
+For Ruby 2.0 ~ 2.2, please use multi_range <= 2.1.
 
 ## Installation
 


### PR DESCRIPTION
since we encounter Segmentation fault and have no idea how to fix it

error message:
```
Installing Bundler
  Bundler 2 requires Ruby 2.3+, using Bundler 1 on Ruby <= 2.2
  /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v ~> 1.0
  ERROR:  While executing gem ... (RuntimeError)
      Marshal.load reentered at marshal_load
  Took   0.38 seconds
Error: The process '/opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem' failed with exit code 1
```