### PR TITLE
Fix: result should not be empty when intersection with inclusive range with one element

### DIFF
--- a/lib/multi_range.rb
+++ b/lib/multi_range.rb
@@ -62,7 +62,9 @@ class MultiRange
     other_ranges = MultiRange.new(other).merge_overlaps.ranges
     tree = IntervalTree::Tree.new(other_ranges)
     intersected_ranges = merge_overlaps.ranges.flat_map do |range|
-      matching_ranges_converted_to_exclusive = tree.search(range) || []
+      # A workaround for the issue: https://github.com/greensync/interval-tree/issues/17
+      query = (range.first == range.last) ? range.first : range
+      matching_ranges_converted_to_exclusive = tree.search(query) || []
 
       # The interval tree converts interval endings to exclusive, so we need to restore the original
       matching_ranges = matching_ranges_converted_to_exclusive.map do |matching_range_converted_to_exclusive|

--- a/test/range_intersection_test.rb
+++ b/test/range_intersection_test.rb
@@ -120,4 +120,14 @@ class RangeIntersectionTest < Minitest::Test
       ).ranges
     end
   end
+
+  def test_inclusive_range_with_one_element
+    multi_range = MultiRange.new([10..10])
+    assert_before_and_after(
+      proc{ multi_range.ranges },
+      proc{ multi_range &= [10..20] },
+      :before => [10..10],
+      :after  => [10..10]
+    )
+  end
 end


### PR DESCRIPTION
Resolve: https://github.com/khiav223577/multi_range/issues/30