### PR TITLE
Fix: edge case of intersection when two range have only one point overlaps

### DIFF
--- a/lib/multi_range.rb
+++ b/lib/multi_range.rb
@@ -68,9 +68,7 @@ class MultiRange
     tree = IntervalTree::Tree.new(other_ranges){|l, r| r ? (l...(r + 1)) : l...nil }
 
     intersected_ranges = merge_overlaps.ranges.flat_map do |range|
-      # A workaround for the issue: https://github.com/greensync/interval-tree/issues/17
-      query = (range.first == range.last) ? range.first : range
-      matching_ranges_converted_to_exclusive = tree.search(query) || []
+      matching_ranges_converted_to_exclusive = tree.search(range) || []
 
       # The interval tree converts interval endings to exclusive, so we need to restore the original
       matching_ranges = matching_ranges_converted_to_exclusive.map do |matching_range_converted_to_exclusive|

--- a/test/range_difference_test.rb
+++ b/test/range_difference_test.rb
@@ -134,6 +134,15 @@ class RangeDifferenceTest < Minitest::Test
     )
   end
 
+  def test_one_point_overlaps
+    assert_before_and_after(
+      proc{ @multi_range.ranges },
+      proc{ @multi_range -= 600..800 },
+      :before => [0..100, 200..300, 500..600],
+      :after  => [0..100, 200..300, 500...600]
+    )
+  end
+
   def test_multi_range
     assert_before_and_after(
       proc{ @multi_range.ranges },

--- a/test/range_intersection_test.rb
+++ b/test/range_intersection_test.rb
@@ -191,6 +191,15 @@ class RangeIntersectionTest < Minitest::Test
     )
   end
 
+  def test_one_point_overlaps
+    assert_before_and_after(
+      proc{ @day_range.ranges },
+      proc{ @day_range &= 7..20 },
+      :before => [1..7],
+      :after  => [7..7]
+    )
+  end
+
   def test_unbounded_range_without_left_border
     skip if not SUPPORT_UNBOUNDED_RANGE_SYNTAX
 
@@ -232,6 +241,17 @@ class RangeIntersectionTest < Minitest::Test
       proc{ @day_range &= (4...nil) },
       :before => [1..7],
       :after  => [4..7]
+    )
+  end
+
+  def test_unbounded_range_without_right_border_full_covered
+    skip if not SUPPORT_UNBOUNDED_RANGE_SYNTAX
+
+    assert_before_and_after(
+      proc{ @day_range.ranges },
+      proc{ @day_range &= (0..nil) },
+      :before => [1..7],
+      :after  => [1..7]
     )
   end
 

--- a/test/range_intersection_test.rb
+++ b/test/range_intersection_test.rb
@@ -187,7 +187,7 @@ class RangeIntersectionTest < Minitest::Test
       proc{ multi_range2.ranges },
       proc{ multi_range2 &= multi_range1 },
       :before => [10...10],
-      :after  => [10...10]
+      :after  => []
     )
   end
 

--- a/test/range_overlap_test.rb
+++ b/test/range_overlap_test.rb
@@ -49,6 +49,11 @@ class RangeOverlapTest < Minitest::Test
     assert_equal false, @degree_range.overlaps?(370..400)
   end
 
+  def test_one_point_overlaps
+    assert_equal true, @multi_range.overlaps?(600..800)
+    assert_equal false, @degree_range.overlaps?(360..800)
+  end
+
   def test_multi_range
     assert_equal true, @multi_range.overlaps?(50..550)
   end
@@ -79,5 +84,11 @@ class RangeOverlapTest < Minitest::Test
     assert_equal true, MultiRange.new([nil..100]).overlaps?(MultiRange.new([50...nil]))
     assert_equal true, MultiRange.new([nil..50]).overlaps?(MultiRange.new([50...nil]))
     assert_equal false, MultiRange.new([nil...50]).overlaps?(MultiRange.new([50...nil]))
+  end
+
+  def test_covered_by_unbounded_range
+    skip if not SUPPORT_UNBOUNDED_RANGE_SYNTAX
+
+    assert_equal true, MultiRange.new([1..7]).overlaps?(MultiRange.new([0...nil]))
   end
 end

--- a/test/range_union_test.rb
+++ b/test/range_union_test.rb
@@ -143,9 +143,25 @@ class RangeUnionTest < Minitest::Test
   def test_other_multi_range_and_not_overlap
     assert_before_and_after(
       proc{ @multi_range.ranges },
-      proc{ @multi_range |= MultiRange.new([-10..-5, 105..199, 400, 700..900]) },
+      proc{ @multi_range |= 600..800 },
       :before => [0..100, 200..300, 500..600],
-      :after  => [-10..-5, 0..100, 105..300, 400..400, 500..600, 700..900]
+      :after => [0..100, 200..300, 500..800]
+    )
+
+    assert_before_and_after(
+      proc{ @degree_range.ranges },
+      proc{ @degree_range |= 360..400 },
+      :before => [0...360],
+      :after  => [0..400]
+    )
+  end
+
+  def test_one_point_overlaps
+    assert_before_and_after(
+      proc{ @multi_range.ranges },
+      proc{ @multi_range |= 600..800 },
+      :before => [0..100, 200..300, 500..600],
+      :after  => [0..100, 200..300, 500..800]
     )
   end
 


### PR DESCRIPTION
Resolve #30, #38, https://github.com/greensync/interval-tree/issues/17